### PR TITLE
Fixed empty-parens bug on DashboardPage.scala

### DIFF
--- a/src/main/scala/scalafx/ensemble/stage/DashboardPage.scala
+++ b/src/main/scala/scalafx/ensemble/stage/DashboardPage.scala
@@ -41,7 +41,7 @@ class DashboardPage(dashPart: String = "dashboard") extends DisplayablePage {
 
   def getPage = {
     val thumbs = dashPart match {
-      case "dashboard" => tree.getDashThumbsCtrl()
+      case "dashboard" => tree.getDashThumbsCtrl
       case _           => tree.getDashThumb(dashPart)
     }
 


### PR DESCRIPTION
This pull fixes a syntax error preventing compilation of DashboardPage.scala as explained in issue #18
